### PR TITLE
Add option for additional script at the end body

### DIFF
--- a/Layout.vue
+++ b/Layout.vue
@@ -28,23 +28,26 @@ export default {
   beforeMount () {
     const bodyScripts = this.$site.themeConfig.bodyScripts
     if (bodyScripts && bodyScripts.length) {
-      bodyScripts.map(scriptConfig => this.createBodyScripts(scriptConfig))
+      bodyScripts.forEach(scriptConfig => this.createBodyScripts(scriptConfig))
     }
   },
 
   methods: {
     createBodyScripts (config) {
-      const htmlElement = document.createElement(config[0])
-      const elementAttributes = config[1]
+      const { tagName, attributes, innerHTML } = config
 
-      Object.keys(elementAttributes).map(attr => {
-        if (attr === 'content') {
-          htmlElement.innerHTML = elementAttributes[attr]
-          return
-        };
+      const htmlElement = document.createElement(tagName)
+      const attributesKeys = Object.keys(attributes)
 
-        htmlElement.setAttribute(attr, elementAttributes[attr])
-      })
+      if (attributesKeys.length) {
+        attributesKeys.forEach(attr => {
+          htmlElement.setAttribute(attr, attributes[attr])
+        })
+      }
+
+      if (innerHTML && innerHTML.length) {
+        htmlElement.innerHTML = innerHTML
+      }
 
       document.body.appendChild(htmlElement)
     },

--- a/Layout.vue
+++ b/Layout.vue
@@ -24,6 +24,31 @@ export default {
       return layout.toLowerCase()
     },
   },
+
+  beforeMount () {
+    const bodyScripts = this.$site.themeConfig.bodyScripts
+    if (bodyScripts && bodyScripts.length) {
+      bodyScripts.map(scriptConfig => this.createBodyScripts(scriptConfig))
+    }
+  },
+
+  methods: {
+    createBodyScripts (config) {
+      const htmlElement = document.createElement(config[0])
+      const elementAttributes = config[1]
+
+      Object.keys(elementAttributes).map(attr => {
+        if (attr === 'content') {
+          htmlElement.innerHTML = elementAttributes[attr]
+          return
+        };
+
+        htmlElement.setAttribute(attr, elementAttributes[attr])
+      })
+
+      document.body.appendChild(htmlElement)
+    },
+  },
 }
 </script>
 

--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,11 @@ module.exports = {
       dribbble: 'netguru',
       behance: 'netguru',
     },
+    bodyScripts: [ // Allows to pass additional scripts at the end of body
+      // First pass html element, than object with attributes. Key 'content' is reserved to pass values in innerHTML
+      ['script', { id: 'some-analytics', async: true, defer: true, src: '//some-analytics.js' }],
+      ['noscript', { id: 'some-iframe-analytics', defer: true, src: 'asd', content: '<h1>It goes inside element</h1>' }]
+    ],
   },
 
   chainWebpack: (config) => {

--- a/Readme.md
+++ b/Readme.md
@@ -51,9 +51,15 @@ module.exports = {
       behance: 'netguru',
     },
     bodyScripts: [ // Allows to pass additional scripts at the end of body
-      // First pass html element, than object with attributes. Key 'content' is reserved to pass values in innerHTML
-      ['script', { id: 'some-analytics', async: true, defer: true, src: '//some-analytics.js' }],
-      ['noscript', { id: 'some-iframe-analytics', defer: true, src: 'asd', content: '<h1>It goes inside element</h1>' }]
+      {
+        tagName: 'script', // required
+        attributes: { id: 'some-analytics', async: true, defer: true, src: '//some-analytics.js' } // required
+      },
+      {
+        tagName: 'noscript', // required
+        attributes: {}, // required (can be empty)
+        innerHTML: '<h1>Any content</h1>' // optional
+      }
     ],
   },
 


### PR DESCRIPTION
There is sometimes a need to add some custom scripts at the end of `<body />`. Those scripts could be tracking ones, chat widgets and so. 
Adding in the body can prevent blocking from page loading. 

Standard VuePress config doesn't allow you to pass that configuration.