### PR TITLE
Add option for chapter start and articles displayed in chapter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -255,13 +255,17 @@ This will produce a following outcome:
 
 ### LandingChapters
 
-Section will display first three chapters with sections.
+Section will display first three chapters with sections. You can provide additioanl option `chapterDisplayStart` and pass any number. That number will be treated as a start chapter.
+
+There is also an option `limitSectionInChapter` to limit displayed sections in chapters. By default, all sections will be displayed.
 
 ```html
 <LandingChapters
   intro="Short intro text"
   img="image.svg"
   imgAlt="image is displayed under intro text"
+  :chapterDisplayStart="3" // optional, default is 0
+  :limitSectionInChapter="7" // optional, default shows all
 />
 ```
 

--- a/components/ChapterBlocks.vue
+++ b/components/ChapterBlocks.vue
@@ -50,11 +50,17 @@ export default {
       type: Array,
       required: true,
     },
+    limitSectionInChapter: {
+      type: Number,
+      default: undefined,
+    },
   },
 
   computed: {
     sections () {
-      return chapter => chapter.headers && chapter.headers.filter(chapter => chapter.level === 2)
+      return chapter => chapter.headers && chapter.headers
+        .filter(chapter => chapter.level === 2)
+        .slice(0, this.limitSectionInChapter)
     },
   },
 }

--- a/global-components/LandingChapters.vue
+++ b/global-components/LandingChapters.vue
@@ -22,7 +22,10 @@
         </div>
       </div>
       <div class="landing-chapters__col landing-chapters__col--chapters">
-        <ChapterBlocks :chapters="chapters" />
+        <ChapterBlocks
+          :chapters="chapters"
+          :limit-section-in-chapter="limitSectionInChapter"
+        />
       </div>
       <ReadButton class="button" />
     </div>
@@ -67,11 +70,23 @@ export default {
       type: String,
       default: '',
     },
+    chapterDisplayStart: {
+      type: Number,
+      default: 0,
+    },
+    limitSectionInChapter: {
+      type: Number,
+      default: undefined,
+    },
   },
 
   computed: {
+    chapterDisplayEnd () {
+      return this.chapterDisplayStart + 3
+    },
+
     chapters () {
-      return this.$chapters.slice(0, 3)
+      return this.$chapters.slice(this.chapterDisplayStart, this.chapterDisplayEnd)
     },
   },
 }


### PR DESCRIPTION
`LandingChapters` displays all chapters, even if they are so-called 'introduction' and for home page, we would like to skip it. The provided option allows to set start of the chapter to display. 
Second option also allows to limit displayed section in chapter block on the home page.