### PR TITLE
Create option for custom intro for ChapterBlock

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,8 @@ layout: chapter
 title: "Example title of Chapter 2"
 chapter_number: "02"
 description: In this chapter you will ...
+chapter_home_intro:
+- some new custom text
 ---
 
 # Example title of Chapter 2
@@ -137,6 +139,7 @@ Chapter content goes here.
 ```
 
 - Fields: `layout`, `title` and `chapter_number` are required.
+- Field `chapter_home_intro` is optional and it is used for `<LandingChapters />` intro text. By default `<LandingChapters />` displays chapter's heading level 2.
 - `description` field is optional, if present - it will be places in proper meta tags on the page. Defaults to the description from `.vuepress/config.js`
 - Make sure that `title` in front matter corresponds to the primary heading - as in the above example.
 - Use only one H1 heading (`# ...`).

--- a/components/ChapterBlock.vue
+++ b/components/ChapterBlock.vue
@@ -89,8 +89,8 @@ export default {
 
   computed: {
     sections () {
-      return chapter => {
-        const { chapter_home_intro: chapterHomeIntro } = chapter.frontmatter
+      return ({ frontmatter, headers }) => {
+        const { chapter_home_intro: chapterHomeIntro } = frontmatter
 
         if (chapterHomeIntro) {
           return chapterHomeIntro.map((intro, index) => ({
@@ -99,7 +99,7 @@ export default {
           }))
         }
 
-        const chapterSections = chapter.headers && chapter.headers.filter(chapter => chapter.level === 2)
+        const chapterSections = headers && headers.filter(chapter => chapter.level === 2)
 
         return this.limitSectionInChapter !== 0 && chapterSections
           ? chapterSections.slice(0, this.limitSectionInChapter)

--- a/components/ChapterBlock.vue
+++ b/components/ChapterBlock.vue
@@ -90,6 +90,15 @@ export default {
   computed: {
     sections () {
       return chapter => {
+        const { chapter_home_intro: chapterHomeIntro } = chapter.frontmatter
+
+        if (chapterHomeIntro) {
+          return chapterHomeIntro.map((intro, index) => ({
+            key: index,
+            title: intro,
+          }))
+        }
+
         const chapterSections = chapter.headers && chapter.headers.filter(chapter => chapter.level === 2)
 
         return this.limitSectionInChapter !== 0 && chapterSections


### PR DESCRIPTION
## Description
`<LandingChapters />` displays by default chapter's second-level headings. 

Those can be too long and because of that, we're providing an option to pass custom text via frontmatter block to replace headings in `<LandingChapters />`